### PR TITLE
Scale the default relay, mining, and wallet fee down by 100x

### DIFF
--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -26,7 +26,7 @@ static constexpr uint64_t DEFAULT_MAX_GENERATED_BLOCK_SIZE = 2 * ONE_MEGABYTE;
  * Default for -blockmintxfee, which sets the minimum feerate for a transaction
  * in blocks created by mining code.
  */
-static constexpr Amount DEFAULT_BLOCK_MIN_TX_FEE_PER_KB(1000 * FIXOSHI);
+static constexpr Amount DEFAULT_BLOCK_MIN_TX_FEE_PER_KB(10 * FIXOSHI);
 /**
  * The maximum size for transactions we're willing to relay/mine.
  */
@@ -64,7 +64,7 @@ static constexpr unsigned int DEFAULT_BYTES_PER_SIGOP = 50;
  * only increase the dust limit after prior releases were already not creating
  * outputs below the new threshold.
  */
-static constexpr Amount DUST_RELAY_TX_FEE(1000 * FIXOSHI);
+static constexpr Amount DUST_RELAY_TX_FEE(10 * FIXOSHI);
 
 /**
  * When transactions fail script evaluations under standard flags, this flagset

--- a/src/validation.h
+++ b/src/validation.h
@@ -68,7 +68,7 @@ static constexpr bool DEFAULT_WHITELISTRELAY = true;
 /** Default for -whitelistforcerelay. */
 static constexpr bool DEFAULT_WHITELISTFORCERELAY = true;
 /** Default for -minrelaytxfee, minimum relay fee for transactions */
-static constexpr Amount DEFAULT_MIN_RELAY_TX_FEE_PER_KB(1000 * FIXOSHI);
+static constexpr Amount DEFAULT_MIN_RELAY_TX_FEE_PER_KB(10 * FIXOSHI);
 /** Default for -excessutxocharge for transactions transactions */
 static constexpr Amount DEFAULT_UTXO_FEE = Amount::zero();
 //! -maxtxfee default

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -78,11 +78,9 @@ static constexpr unsigned int DEFAULT_KEYPOOL_SIZE = 1000;
 //! -paytxfee default
 constexpr Amount DEFAULT_PAY_TX_FEE = Amount::zero();
 //! -fallbackfee default
-static constexpr Amount DEFAULT_FALLBACK_FEE(20000 * FIXOSHI);
+static constexpr Amount DEFAULT_FALLBACK_FEE(200 * FIXOSHI);
 //! -mintxfee default
-static constexpr Amount DEFAULT_TRANSACTION_MINFEE_PER_KB = 1000 * FIXOSHI;
-//! minimum recommended increment for BIP 125 replacement txs
-static constexpr Amount WALLET_INCREMENTAL_RELAY_FEE(5000 * FIXOSHI);
+static constexpr Amount DEFAULT_TRANSACTION_MINFEE_PER_KB = 10 * FIXOSHI;
 //! Default for -spendzeroconfchange
 static constexpr bool DEFAULT_SPEND_ZEROCONF_CHANGE = true;
 //! Default for -walletrejectlongchains


### PR DESCRIPTION
As discussed in chat with Licho:

Since fixtoshi's seem like they will hold more value -- and since the
circulating supply is so small now, we should probably make the default
fee be 0.01 fix/B (or 10 fix/kB).  This is basically 1 fix per 100B (minimum
tx size is 100B).

This commit also scales the dust threshold down by ~100x (since dust is
calculated off of minimum fee in a roundabout way).

This allows us to spend small amounts and also not pay high fees.

Additionally, the mining minimum fee was also set to the same as the
relay fee.