### PR TITLE
Backport from BCHN: Update build system to use C++17

### DIFF
--- a/build-aux/m4/ax_cxx_compile_stdcxx.m4
+++ b/build-aux/m4/ax_cxx_compile_stdcxx.m4
@@ -1,5 +1,5 @@
 # ===========================================================================
-#   http://www.gnu.org/software/autoconf-archive/ax_cxx_compile_stdcxx.html
+#  https://www.gnu.org/software/autoconf-archive/ax_cxx_compile_stdcxx.html
 # ===========================================================================
 #
 # SYNOPSIS
@@ -33,21 +33,23 @@
 #   Copyright (c) 2014, 2015 Google Inc.; contributed by Alexey Sokolov <sokolov@google.com>
 #   Copyright (c) 2015 Paul Norman <penorman@mac.com>
 #   Copyright (c) 2015 Moritz Klammler <moritz@klammler.eu>
+#   Copyright (c) 2016, 2018 Krzesimir Nowak <qdlacz@gmail.com>
+#   Copyright (c) 2019 Enji Cooper <yaneurabeya@gmail.com>
 #
 #   Copying and distribution of this file, with or without modification, are
 #   permitted in any medium without royalty provided the copyright notice
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 4
+#serial 11
 
 dnl  This macro is based on the code from the AX_CXX_COMPILE_STDCXX_11 macro
 dnl  (serial version number 13).
 
 AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
-  m4_if([$1], [11], [],
-        [$1], [14], [],
-        [$1], [17], [m4_fatal([support for C++17 not yet implemented in AX_CXX_COMPILE_STDCXX])],
+  m4_if([$1], [11], [ax_cxx_compile_alternatives="11 0x"],
+        [$1], [14], [ax_cxx_compile_alternatives="14 1y"],
+        [$1], [17], [ax_cxx_compile_alternatives="17 1z"],
         [m4_fatal([invalid first argument `$1' to AX_CXX_COMPILE_STDCXX])])dnl
   m4_if([$2], [], [],
         [$2], [ext], [],
@@ -57,26 +59,13 @@ AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
         [$3], [mandatory], [ax_cxx_compile_cxx$1_required=true],
         [$3], [optional], [ax_cxx_compile_cxx$1_required=false],
         [m4_fatal([invalid third argument `$3' to AX_CXX_COMPILE_STDCXX])])
-  m4_if([$4], [], [ax_cxx_compile_cxx$1_try_default=true],
-        [$4], [default], [ax_cxx_compile_cxx$1_try_default=true],
-        [$4], [nodefault], [ax_cxx_compile_cxx$1_try_default=false],
-        [m4_fatal([invalid fourth argument `$4' to AX_CXX_COMPILE_STDCXX])])
   AC_LANG_PUSH([C++])dnl
   ac_success=no
 
-  m4_if([$4], [nodefault], [], [dnl
-  AC_CACHE_CHECK(whether $CXX supports C++$1 features by default,
-  ax_cv_cxx_compile_cxx$1,
-  [AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_testbody_$1])],
-    [ax_cv_cxx_compile_cxx$1=yes],
-    [ax_cv_cxx_compile_cxx$1=no])])
-  if test x$ax_cv_cxx_compile_cxx$1 = xyes; then
-    ac_success=yes
-  fi])
-
   m4_if([$2], [noext], [], [dnl
   if test x$ac_success = xno; then
-    for switch in -std=gnu++$1 -std=gnu++0x; do
+    for alternative in ${ax_cxx_compile_alternatives}; do
+      switch="-std=gnu++${alternative}"
       cachevar=AS_TR_SH([ax_cv_cxx_compile_cxx$1_$switch])
       AC_CACHE_CHECK(whether $CXX supports C++$1 features with $switch,
                      $cachevar,
@@ -102,22 +91,27 @@ AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
     dnl HP's aCC needs +std=c++11 according to:
     dnl http://h21007.www2.hp.com/portal/download/files/unprot/aCxx/PDF_Release_Notes/769149-001.pdf
     dnl Cray's crayCC needs "-h std=c++11"
-    for switch in -std=c++$1 -std=c++0x +std=c++$1 "-h std=c++$1"; do
-      cachevar=AS_TR_SH([ax_cv_cxx_compile_cxx$1_$switch])
-      AC_CACHE_CHECK(whether $CXX supports C++$1 features with $switch,
-                     $cachevar,
-        [ac_save_CXX="$CXX"
-         CXX="$CXX $switch"
-         AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_testbody_$1])],
-          [eval $cachevar=yes],
-          [eval $cachevar=no])
-         CXX="$ac_save_CXX"])
-      if eval test x\$$cachevar = xyes; then
-        CXX="$CXX $switch"
-        if test -n "$CXXCPP" ; then
-          CXXCPP="$CXXCPP $switch"
+    for alternative in ${ax_cxx_compile_alternatives}; do
+      for switch in -std=c++${alternative} +std=c++${alternative} "-h std=c++${alternative}"; do
+        cachevar=AS_TR_SH([ax_cv_cxx_compile_cxx$1_$switch])
+        AC_CACHE_CHECK(whether $CXX supports C++$1 features with $switch,
+                       $cachevar,
+          [ac_save_CXX="$CXX"
+           CXX="$CXX $switch"
+           AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_testbody_$1])],
+            [eval $cachevar=yes],
+            [eval $cachevar=no])
+           CXX="$ac_save_CXX"])
+        if eval test x\$$cachevar = xyes; then
+          CXX="$CXX $switch"
+          if test -n "$CXXCPP" ; then
+            CXXCPP="$CXXCPP $switch"
+          fi
+          ac_success=yes
+          break
         fi
-        ac_success=yes
+      done
+      if test x$ac_success = xyes; then
         break
       fi
     done
@@ -154,6 +148,11 @@ m4_define([_AX_CXX_COMPILE_STDCXX_testbody_14],
   _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
 )
 
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_17],
+  _AX_CXX_COMPILE_STDCXX_testbody_new_in_11
+  _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
+  _AX_CXX_COMPILE_STDCXX_testbody_new_in_17
+)
 
 dnl  Tests for new features in C++11
 
@@ -191,11 +190,13 @@ namespace cxx11
 
     struct Base
     {
+      virtual ~Base() {}
       virtual void f() {}
     };
 
     struct Derived : public Base
     {
+      virtual ~Derived() override {}
       virtual void f() override {}
     };
 
@@ -524,7 +525,7 @@ namespace cxx14
 
   }
 
-  namespace test_digit_seperators
+  namespace test_digit_separators
   {
 
     constexpr auto ten_million = 100'000'000;
@@ -564,5 +565,387 @@ namespace cxx14
 }  // namespace cxx14
 
 #endif  // __cplusplus >= 201402L
+
+]])
+
+
+dnl  Tests for new features in C++17
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_17], [[
+
+// If the compiler admits that it is not ready for C++17, why torture it?
+// Hopefully, this will speed up the test.
+
+#ifndef __cplusplus
+
+#error "This is not a C++ compiler"
+
+#elif __cplusplus < 201703L
+
+#error "This is not a C++17 compiler"
+
+#else
+
+#include <initializer_list>
+#include <utility>
+#include <type_traits>
+
+namespace cxx17
+{
+
+  namespace test_constexpr_lambdas
+  {
+
+    constexpr int foo = [](){return 42;}();
+
+  }
+
+  namespace test::nested_namespace::definitions
+  {
+
+  }
+
+  namespace test_fold_expression
+  {
+
+    template<typename... Args>
+    int multiply(Args... args)
+    {
+      return (args * ... * 1);
+    }
+
+    template<typename... Args>
+    bool all(Args... args)
+    {
+      return (args && ...);
+    }
+
+  }
+
+  namespace test_extended_static_assert
+  {
+
+    static_assert (true);
+
+  }
+
+  namespace test_auto_brace_init_list
+  {
+
+    auto foo = {5};
+    auto bar {5};
+
+    static_assert(std::is_same<std::initializer_list<int>, decltype(foo)>::value);
+    static_assert(std::is_same<int, decltype(bar)>::value);
+  }
+
+  namespace test_typename_in_template_template_parameter
+  {
+
+    template<template<typename> typename X> struct D;
+
+  }
+
+  namespace test_fallthrough_nodiscard_maybe_unused_attributes
+  {
+
+    int f1()
+    {
+      return 42;
+    }
+
+    [[nodiscard]] int f2()
+    {
+      [[maybe_unused]] auto unused = f1();
+
+      switch (f1())
+      {
+      case 17:
+        f1();
+        [[fallthrough]];
+      case 42:
+        f1();
+      }
+      return f1();
+    }
+
+  }
+
+  namespace test_extended_aggregate_initialization
+  {
+
+    struct base1
+    {
+      int b1, b2 = 42;
+    };
+
+    struct base2
+    {
+      base2() {
+        b3 = 42;
+      }
+      int b3;
+    };
+
+    struct derived : base1, base2
+    {
+        int d;
+    };
+
+    derived d1 {{1, 2}, {}, 4};  // full initialization
+    derived d2 {{}, {}, 4};      // value-initialized bases
+
+  }
+
+  namespace test_general_range_based_for_loop
+  {
+
+    struct iter
+    {
+      int i;
+
+      int& operator* ()
+      {
+        return i;
+      }
+
+      const int& operator* () const
+      {
+        return i;
+      }
+
+      iter& operator++()
+      {
+        ++i;
+        return *this;
+      }
+    };
+
+    struct sentinel
+    {
+      int i;
+    };
+
+    bool operator== (const iter& i, const sentinel& s)
+    {
+      return i.i == s.i;
+    }
+
+    bool operator!= (const iter& i, const sentinel& s)
+    {
+      return !(i == s);
+    }
+
+    struct range
+    {
+      iter begin() const
+      {
+        return {0};
+      }
+
+      sentinel end() const
+      {
+        return {5};
+      }
+    };
+
+    void f()
+    {
+      range r {};
+
+      for (auto i : r)
+      {
+        [[maybe_unused]] auto v = i;
+      }
+    }
+
+  }
+
+  namespace test_lambda_capture_asterisk_this_by_value
+  {
+
+    struct t
+    {
+      int i;
+      int foo()
+      {
+        return [*this]()
+        {
+          return i;
+        }();
+      }
+    };
+
+  }
+
+  namespace test_enum_class_construction
+  {
+
+    enum class byte : unsigned char
+    {};
+
+    byte foo {42};
+
+  }
+
+  namespace test_constexpr_if
+  {
+
+    template <bool cond>
+    int f ()
+    {
+      if constexpr(cond)
+      {
+        return 13;
+      }
+      else
+      {
+        return 42;
+      }
+    }
+
+  }
+
+  namespace test_selection_statement_with_initializer
+  {
+
+    int f()
+    {
+      return 13;
+    }
+
+    int f2()
+    {
+      if (auto i = f(); i > 0)
+      {
+        return 3;
+      }
+
+      switch (auto i = f(); i + 4)
+      {
+      case 17:
+        return 2;
+
+      default:
+        return 1;
+      }
+    }
+
+  }
+
+  namespace test_template_argument_deduction_for_class_templates
+  {
+
+    template <typename T1, typename T2>
+    struct pair
+    {
+      pair (T1 p1, T2 p2)
+        : m1 {p1},
+          m2 {p2}
+      {}
+
+      T1 m1;
+      T2 m2;
+    };
+
+    void f()
+    {
+      [[maybe_unused]] auto p = pair{13, 42u};
+    }
+
+  }
+
+  namespace test_non_type_auto_template_parameters
+  {
+
+    template <auto n>
+    struct B
+    {};
+
+    B<5> b1;
+    B<'a'> b2;
+
+  }
+
+  namespace test_structured_bindings
+  {
+
+    int arr[2] = { 1, 2 };
+    std::pair<int, int> pr = { 1, 2 };
+
+    auto f1() -> int(&)[2]
+    {
+      return arr;
+    }
+
+    auto f2() -> std::pair<int, int>&
+    {
+      return pr;
+    }
+
+    struct S
+    {
+      int x1 : 2;
+      volatile double y1;
+    };
+
+    S f3()
+    {
+      return {};
+    }
+
+    auto [ x1, y1 ] = f1();
+    auto& [ xr1, yr1 ] = f1();
+    auto [ x2, y2 ] = f2();
+    auto& [ xr2, yr2 ] = f2();
+    const auto [ x3, y3 ] = f3();
+
+  }
+
+  namespace test_exception_spec_type_system
+  {
+
+    struct Good {};
+    struct Bad {};
+
+    void g1() noexcept;
+    void g2();
+
+    template<typename T>
+    Bad
+    f(T*, T*);
+
+    template<typename T1, typename T2>
+    Good
+    f(T1*, T2*);
+
+    static_assert (std::is_same_v<Good, decltype(f(g1, g2))>);
+
+  }
+
+  namespace test_inline_variables
+  {
+
+    template<class T> void f(T)
+    {}
+
+    template<class T> inline T g(T)
+    {
+      return T{};
+    }
+
+    template<> inline void f<>(int)
+    {}
+
+    template<> int g<>(int)
+    {
+      return 5;
+    }
+
+  }
+
+}  // namespace cxx17
+
+#endif  // __cplusplus < 201703L
 
 ]])

--- a/configure.ac
+++ b/configure.ac
@@ -60,8 +60,10 @@ case $host in
      lt_cv_deplibs_check_method="pass_all"
   ;;
 esac
-dnl Require C++14 compiler (no GNU extensions)
-AX_CXX_COMPILE_STDCXX([14], [noext], [mandatory], [nodefault])
+
+dnl Require C++17 compiler (no GNU extensions)
+AX_CXX_COMPILE_STDCXX([17], [noext], [mandatory])
+
 dnl Check if -latomic is required for <std::atomic>
 CHECK_ATOMIC
 

--- a/contrib/testgen/CMakeLists.txt
+++ b/contrib/testgen/CMakeLists.txt
@@ -9,8 +9,9 @@ else()
     find_program_or_fail(CSPLIT_EXECUTABLE csplit)
 endif()
 
-# This project can take advantage of C++14.
-set(CMAKE_CXX_STANDARD 14)
+# This project must use C++17
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_executable(gen_asert_test_vectors
     EXCLUDE_FROM_ALL

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -45,7 +45,7 @@ If you want to run ZMQ tests with the test framework, you need the zmq python mo
 Build Bitcoin Static
 ------------------------
 
-Before you start building, please make sure that your compiler supports C++14.
+Before you start building, please make sure that your compiler supports C++17.
 
 Clone the Bitcoin Static source code and cd into `bitcoin-cash-node`
 

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -27,7 +27,7 @@ See [dependencies.md](dependencies.md) or your OS specific guide in build-*.md.
 If you wish to compile the dependencies from source yourself, please see
 instructions in [depends](/depends/README.md).
 
-Please make sure that your compiler supports C++14.
+Please make sure that your compiler supports C++17.
 
 Assuming you have all the necessary dependencies installed the commands below will
 build the node, with the `bitcoin-qt` GUI-client as well.

--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -22,7 +22,7 @@ Other options which may work, but which have not been extensively tested are
 * On Windows, using a native compiler tool chain such as
   [Visual Studio](https://www.visualstudio.com).
 
-In any case please make sure that the compiler supports C++14.
+In any case please make sure that the compiler supports C++17.
 
 **Note** These notes cover building binaries from source, for running Bitcoin
 Cash Node natively under Windows. If you just want to run Bitcoin Static,

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -9,13 +9,13 @@ These dependencies are required:
 | --- | --- | --- | --- | --- | --- |--- | --- |
 | Berkeley DB | [5.3.28](http://www.oracle.com/technetwork/database/database-technologies/berkeleydb/downloads/index.html) | 5.3 | No |  |  | Wallet storage | Only needed when wallet enabled  |
 | Boost | [1.70.0](http://www.boost.org/users/download/) | 1.58.0 | No |  |  |  Utility          | Library for threading, data structures, etc
-| Clang |  | [3.4](http://llvm.org/releases/download.html) (C++14 support) |  |  |  |  |  |
+| Clang |  | [5](http://llvm.org/releases/download.html) (C++17 support) |  |  |  |  |  |
 | CMake |  | [3.13](https://cmake.org/download/) |  |  |  |  |  |
 | D-Bus | [1.10.18](https://cgit.freedesktop.org/dbus/dbus/tree/NEWS?h=dbus-1.10) |  | No | Yes |  |  |  |
 | Expat | [2.2.5](https://libexpat.github.io/) |  | No | Yes |  |  |  |
 | fontconfig | [2.12.6](https://www.freedesktop.org/software/fontconfig/release/) |  | No | Yes |  |  |  |
 | FreeType | [2.7.1](http://download.savannah.gnu.org/releases/freetype) |  | No |  |  |  |  |
-| GCC |  | [5.0](https://gcc.gnu.org/) (C++14 support) |  |  |  |  |  |
+| GCC |  | [7.0](https://gcc.gnu.org/) (C++17 support) |  |  |  |  |  |
 | HarfBuzz-NG |  |  |  |  |  |  |  |
 | libevent | [2.1.8-stable](https://github.com/libevent/libevent/releases) | 2.0.22 | No |  |  |  Networking       | OS independent asynchronous networking |
 | libjpeg |  |  |  |  | Yes |  |  |

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,7 +2,9 @@
 
 project(bitcoind)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 
 # Default visibility is hidden on all targets.
 set(CMAKE_C_VISIBILITY_PRESET hidden)

--- a/src/compat/assumptions.h
+++ b/src/compat/assumptions.h
@@ -20,6 +20,19 @@
 #error "Bitcoin cannot be compiled without assertions."
 #endif
 
+// Assumption: We assume a C++17 (ISO/IEC 14882:2017) compiler (minimum
+//             requirement).
+// Example(s): We may use use C++17 only constructs such as if constexpr,
+//             structured binding, std::is_same_v, etc.
+// Note:       MSVC does not report the expected __cplusplus value due to
+//             legacy reasons.
+#if !defined(_MSC_VER)
+// N4713 §19.8/p1  [cpp.predefined]/p1::
+// "The name __cplusplus is defined to the value 201703L when compiling a C++
+//  translation unit."
+static_assert(__cplusplus >= 201703L, "C++17 standard assumed");
+#endif
+
 // Assumption: We assume the floating-point types to fulfill the requirements of
 //             IEC 559 (IEEE 754) standard.
 // Example(s): Floating-point division by zero in ConnectBlock,

--- a/src/script/descriptor.cpp
+++ b/src/script/descriptor.cpp
@@ -522,7 +522,7 @@ enum class ParseScriptContext {
  * return true.
  */
 bool Const(const std::string &str, Span<const char> &sp) {
-    if ((size_t)sp.size() >= str.size() &&
+    if (sp.size() >= str.size() &&
         std::equal(str.begin(), str.end(), sp.begin())) {
         sp = sp.subspan(str.size());
         return true;
@@ -535,7 +535,7 @@ bool Const(const std::string &str, Span<const char> &sp) {
  * argument(s).
  */
 bool Func(const std::string &str, Span<const char> &sp) {
-    if ((size_t)sp.size() >= str.size() + 2 && sp[str.size()] == '(' &&
+    if (sp.size() >= str.size() + 2 && sp[str.size()] == '(' &&
         sp[sp.size() - 1] == ')' &&
         std::equal(str.begin(), str.end(), sp.begin())) {
         sp = sp.subspan(str.size() + 1, sp.size() - str.size() - 2);

--- a/src/span.h
+++ b/src/span.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2018 The Bitcoin Core developers
+// Copyright (c) 2020 The Bitcoin developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -6,6 +7,7 @@
 #define BITCOIN_SPAN_H
 
 #include <algorithm>
+#include <cassert>
 #include <cstddef>
 #include <type_traits>
 
@@ -14,58 +16,89 @@
  * It implements a subset of C++20's std::span.
  */
 template <typename C> class Span {
-    C *m_data;
-    std::ptrdiff_t m_size;
+    C *m_data{};
+    std::size_t m_size{};
 
 public:
-    constexpr Span() noexcept : m_data(nullptr), m_size(0) {}
-    constexpr Span(C *data, std::ptrdiff_t size) noexcept
-        : m_data(data), m_size(size) {}
-    constexpr Span(C *data, C *end) noexcept
-        : m_data(data), m_size(end - data) {}
+    constexpr Span() noexcept = default;
+    constexpr Span(C *data, std::size_t size) noexcept : m_data(data), m_size(size) {}
+    constexpr Span(C *data, C *end) noexcept : m_data(data), m_size(end >= data ? end - data : 0) {}
+
+    /** Implicit conversion of spans between compatible types.
+     *
+     *  Specifically, if a pointer to an array of type O can be implicitly converted to a pointer to an array of type
+     *  C, then permit implicit conversion of Span<O> to Span<C>. This matches the behavior of the corresponding
+     *  C++20 std::span constructor.
+     *
+     *  For example this means that a Span<T> can be converted into a Span<const T>.
+     */
+    template <typename O, typename std::enable_if_t<std::is_convertible_v<O (*)[], C (*)[]>, int> = 0>
+    constexpr Span(const Span<O>& other) noexcept : m_data(other.m_data), m_size(other.m_size) {}
+
+    /** Default copy constructor. */
+    constexpr Span(const Span&) noexcept = default;
+
+    /** Default assignment operator. */
+    Span& operator=(const Span& other) noexcept = default;
 
     constexpr C *data() const noexcept { return m_data; }
     constexpr C *begin() const noexcept { return m_data; }
     constexpr C *end() const noexcept { return m_data + m_size; }
-    constexpr std::ptrdiff_t size() const noexcept { return m_size; }
-    constexpr C &operator[](std::ptrdiff_t pos) const noexcept {
-        return m_data[pos];
+    constexpr std::size_t size() const noexcept { return m_size; }
+    constexpr bool empty() const noexcept { return size() == 0; }
+    constexpr C &operator[](std::size_t pos) const noexcept { return m_data[pos]; }
+    constexpr C &front() const noexcept { return *begin(); }
+    constexpr C &back() const noexcept { return *(end()-1); }
+
+    constexpr Span<C> subspan(std::size_t offset) const noexcept {
+        return offset <= m_size? Span<C>(m_data + offset, m_size - offset) : Span<C>(end(), std::size_t{0});
+    }
+    constexpr Span<C> subspan(std::size_t offset, std::size_t count) const noexcept {
+        return offset + count <= m_size ? Span<C>(m_data + offset, count) : Span<C>(end(), std::size_t{0});
+    }
+    constexpr Span<C> first(std::size_t count) const noexcept {
+        return count <= m_size ? Span<C>(m_data, count) : Span<C>(begin(), std::size_t{0});
+    }
+    constexpr Span<C> last(std::size_t count) const noexcept {
+        return count <= m_size ? Span<C>(m_data + m_size - count, count) : Span<C>(end(), std::size_t{0});
     }
 
-    constexpr Span<C> subspan(std::ptrdiff_t offset) const noexcept {
-        return Span<C>(m_data + offset, m_size - offset);
+    /** Pop the last element off, and return a reference to that element.
+        Span must not be empty(); span will decrease in size by 1, having its end() moved back by 1. */
+    constexpr C & pop_back() noexcept {
+        assert(!empty());
+        return m_data[--m_size];
     }
-    constexpr Span<C> subspan(std::ptrdiff_t offset, std::ptrdiff_t count) const
-        noexcept {
-        return Span<C>(m_data + offset, count);
-    }
-    constexpr Span<C> first(std::ptrdiff_t count) const noexcept {
-        return Span<C>(m_data, count);
-    }
-    constexpr Span<C> last(std::ptrdiff_t count) const noexcept {
-        return Span<C>(m_data + m_size - count, count);
+
+    /** Pop the last element off, and return a reference to that element.
+        Span must not be empty(); span will decrease in size by 1, having its begin() moved up by 1. */
+    constexpr C & pop_front() noexcept {
+        assert(!empty());
+        --m_size;
+        return *m_data++;
     }
 
     friend constexpr bool operator==(const Span &a, const Span &b) noexcept {
-        return a.size() == b.size() &&
-               std::equal(a.begin(), a.end(), b.begin());
+        return a.size() == b.size() && std::equal(a.begin(), a.end(), b.begin());
     }
     friend constexpr bool operator!=(const Span &a, const Span &b) noexcept {
         return !(a == b);
     }
     friend constexpr bool operator<(const Span &a, const Span &b) noexcept {
-        return std::lexicographical_compare(a.begin(), a.end(), b.begin(),
-                                            b.end());
+        return std::lexicographical_compare(a.begin(), a.end(), b.begin(), b.end());
     }
     friend constexpr bool operator<=(const Span &a, const Span &b) noexcept {
         return !(b < a);
     }
     friend constexpr bool operator>(const Span &a, const Span &b) noexcept {
-        return (b < a);
+        return b < a;
     }
     friend constexpr bool operator>=(const Span &a, const Span &b) noexcept {
         return !(a < b);
     }
+
+    /** Ensures the convertible-to constructor works */
+    template <typename O> friend class Span;
 };
 
 /** Create a span to a container exposing data() and size().
@@ -78,17 +111,16 @@ public:
  * std::span will have a constructor that implements this functionality
  * directly.
  */
-template <typename A, int N> constexpr Span<A> MakeSpan(A (&a)[N]) {
+template <typename A, std::size_t N>
+constexpr Span<A> MakeSpan(A (&a)[N]) {
     return Span<A>(a, N);
 }
 
+/** Make a span from any container that has .data() and .size() */
 template <typename V>
-constexpr Span<
-    typename std::remove_pointer<decltype(std::declval<V>().data())>::type>
-MakeSpan(V &v) {
-    return Span<
-        typename std::remove_pointer<decltype(std::declval<V>().data())>::type>(
-        v.data(), v.size());
+constexpr auto MakeSpan(V &v) {
+    using ContainerValueType = typename std::remove_pointer_t<decltype(std::declval<V>().data())>;
+    return Span<ContainerValueType>(v.data(), v.size());
 }
 
 #endif // BITCOIN_SPAN_H

--- a/src/test/hash_tests.cpp
+++ b/src/test/hash_tests.cpp
@@ -176,7 +176,7 @@ public:
     }
 
     template <typename Stream> void Unserialize(Stream &s) {
-        unsigned int nVersionDummy;
+        unsigned int nVersionDummy{};
         ::Unserialize(s, VARINT(nVersionDummy));
         ::Unserialize(s, VARINT(value));
     }

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -329,7 +329,7 @@ public:
     template <typename Stream> void Unserialize(Stream &s) {
         uint32_t nCode = 0;
         // version
-        unsigned int nVersionDummy;
+        unsigned int nVersionDummy{};
         ::Unserialize(s, VARINT(nVersionDummy));
         // header code
         ::Unserialize(s, VARINT(nCode));

--- a/src/undo.h
+++ b/src/undo.h
@@ -58,7 +58,7 @@ public:
             // Old versions stored the version number for the last spend of a
             // transaction's outputs. Non-final spends were indicated with
             // height = 0.
-            unsigned int nVersionDummy;
+            unsigned int nVersionDummy{};
             ::Unserialize(s, VARINT(nVersionDummy));
         }
 

--- a/src/univalue/CMakeLists.txt
+++ b/src/univalue/CMakeLists.txt
@@ -3,6 +3,9 @@
 cmake_minimum_required(VERSION 3.13)
 project(univalue)
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 option(UNIVALUE_BUILD_TESTS "Build univalue's unit tests" ON)
 
 # TODO: Version info

--- a/src/univalue/README.md
+++ b/src/univalue/README.md
@@ -53,4 +53,4 @@ Commands to build the library stand-alone:
 make
 ```
 
-ERGN UniValue requires C++14 or later.
+ERGN UniValue requires C++17 or later.

--- a/src/univalue/configure.ac
+++ b/src/univalue/configure.ac
@@ -45,8 +45,8 @@ AC_SUBST(LIBUNIVALUE_AGE)
 LT_INIT
 LT_LANG([C++])
 
-dnl Require C++14 compiler (no GNU extensions)
-AX_CXX_COMPILE_STDCXX([14], [noext], [mandatory], [nodefault])
+dnl Require C++17 compiler (no GNU extensions)
+AX_CXX_COMPILE_STDCXX([17], [noext], [mandatory])
 
 case $host in
   *mingw*)

--- a/test/lint/lint-cpp.sh
+++ b/test/lint/lint-cpp.sh
@@ -10,12 +10,37 @@ export LC_ALL=C
 
 EXIT_CODE=0
 
-OUTPUT=$(git grep -E "boost::bind\(" -- "*.cpp" "*.h")
-if [[ ${OUTPUT} != "" ]]; then
-    echo "Use of boost::bind detected. Use std::bind instead."
-    echo
-    echo "${OUTPUT}"
-    EXIT_CODE=1
-fi
+# Search for PATTERN ($1) and if found, outputs PATTERN_FOUND_MESSAGE ($2)
+# and the offending matches, and sets global EXIT_CODE to 1.
+# PATTERN_FOUND_MESSAGE should include some helpful hints on how to fix the
+# problem, if possible.
+# Variable number of arguments from $3 onwards are taken as file globs
+# which are passed to the 'git grep' search command.
+search_and_report_if_found() {
+    PATTERN="$1"
+    PATTERN_FOUND_MESSAGE="$2"
+    shift 2
+    OUTPUT=$(git grep -E "$PATTERN" -- $@)
+    if [[ ${OUTPUT} != "" ]]; then
+        echo "$PATTERN_FOUND_MESSAGE"
+        echo
+        echo "${OUTPUT}"
+        echo
+        EXIT_CODE=1
+    fi
+}
 
+search_and_report_if_found "boost::bind" \
+                           "Use of boost::bind detected. Use std::bind instead." \
+                           "*.cpp" "*.h"
+
+# C++17 language features we do not want to be used right now since they are
+# not supported on all platforms yet:
+search_and_report_if_found "std::filesystem" \
+   "Use of std::filesystem detected. This is a problem on OSX 10.14 (gitian build). Use boost::filesystem instead." \
+   "*.cpp" "*.h"
+
+search_and_report_if_found "std::variant" \
+   "Use of std::variant detected. This is a problem on OSX 10.14 (gitian build). Use boost::variant instead." \
+   "*.cpp" "*.h"
 exit ${EXIT_CODE}


### PR DESCRIPTION
This contains a few commits from BCHN that enables C++17.  This also squashes some warnings I was getting since
the codebase seemed to use C++17 anyway but without the build system having been updated.
