### PR TITLE
Set the default ports on all nets, set default RPC port as well

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -295,7 +295,7 @@ public:
         netMagic[1] = 212;
         netMagic[2] = 31;
         netMagic[3] = 144;
-        nDefaultPort = 18333;
+        nDefaultPort = 12137;
         nPruneAfterHeight = 1000;
         m_assumed_blockchain_size = 60;
         m_assumed_chain_state_size = 2;
@@ -424,7 +424,7 @@ public:
         netMagic[1] = 0xb7;
         netMagic[2] = 0xda;
         netMagic[3] = 0xaf;
-        nDefaultPort = 28333;
+        nDefaultPort = 22137;
         nPruneAfterHeight = 1000;
         m_assumed_blockchain_size = 1;
         m_assumed_chain_state_size = 1;
@@ -556,7 +556,7 @@ public:
         netMagic[1] = 0xaf;
         netMagic[2] = 0xe1;
         netMagic[3] = 0xa2;
-        nDefaultPort = 38333;
+        nDefaultPort = 32137;
         nPruneAfterHeight = 10000;
         m_assumed_blockchain_size = 100;
         m_assumed_chain_state_size = 10;

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -41,19 +41,19 @@ const CBaseChainParams &BaseParams() {
 std::unique_ptr<CBaseChainParams>
 CreateBaseChainParams(const std::string &chain) {
     if (chain == CBaseChainParams::MAIN) {
-        return std::make_unique<CBaseChainParams>("", 8332);
+        return std::make_unique<CBaseChainParams>("", 2136);
     }
 
     if (chain == CBaseChainParams::TESTNET) {
-        return std::make_unique<CBaseChainParams>("testnet3", 18332);
+        return std::make_unique<CBaseChainParams>("testnet3", 12136);
     }
 
     if (chain == CBaseChainParams::TESTNET4) {
-        return std::make_unique<CBaseChainParams>("testnet4", 28332);
+        return std::make_unique<CBaseChainParams>("testnet4", 22136);
     }
 
     if (chain == CBaseChainParams::SCALENET) {
-        return std::make_unique<CBaseChainParams>("scalenet", 38332);
+        return std::make_unique<CBaseChainParams>("scalenet", 32136);
     }
 
     if (chain == CBaseChainParams::REGTEST) {


### PR DESCRIPTION
Made the default RPC port be 2136 (which is similar to how bitcoin's is
8332, one less than the p2p port of 8333). This is to avoid clashing with
an already-running bitcoind for BCH.

Also made the default ports for possible future testnet/scalenet/etc
be: p2p port xx2137 and RPC port xx2136, where xx is one of: 1,2,3,1
for test3, test4, scale.

Left the regrest ports unchanged (to prevent possible issues with the
python tests no longer working).