### PR TITLE
Fix Windows default directory, regkeys, and a bunch of other stuff

### DIFF
--- a/PackageOptions.cmake
+++ b/PackageOptions.cmake
@@ -1,10 +1,10 @@
 # Package options
 set(CPACK_PACKAGE_VENDOR "${COPYRIGHT_HOLDERS_FINAL}")
-set(CPACK_PACKAGE_DESCRIPTION "Bitcoin Static is a Bitcoin Cash full node implementation.")
+set(CPACK_PACKAGE_DESCRIPTION "Bitcoin Static is an Ergon full node implementation.")
 set(CPACK_PACKAGE_HOMEPAGE_URL "${PROJECT_HOMEPAGE_URL}")
-set(CPACK_PACKAGE_CONTACT "info@bitcoincashnode.org")
+set(CPACK_PACKAGE_CONTACT "info@ergon.moe")
 
-set(CPACK_PACKAGE_INSTALL_DIRECTORY "Bitcoin-Cash-Node")
+set(CPACK_PACKAGE_INSTALL_DIRECTORY "Bitcoin-Static")
 set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/COPYING")
 set(CPACK_PACKAGE_DESCRIPTION_FILE "${CMAKE_SOURCE_DIR}/doc/README_windows.txt")
 

--- a/cmake/modules/NSIS.template.in
+++ b/cmake/modules/NSIS.template.in
@@ -51,9 +51,9 @@ Var StartMenuGroup
 # Installer attributes
 OutFile "@CPACK_TOPLEVEL_DIRECTORY@/@CPACK_OUTPUT_FILE_NAME@"
 !if "@CPACK_SYSTEM_NAME@" == "x86_64-w64-mingw32"
-InstallDir $PROGRAMFILES64\Bitcoin-Cash-Node
+InstallDir $PROGRAMFILES64\Bitcoin-Static
 !else
-InstallDir $PROGRAMFILES\Bitcoin-Cash-Node
+InstallDir $PROGRAMFILES\Bitcoin-Static
 !endif
 CRCCheck on
 XPStyle on
@@ -109,7 +109,7 @@ Section -post SEC0001
     WriteRegDWORD HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" NoModify 1
     WriteRegDWORD HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" NoRepair 1
     WriteRegStr HKCR "@CPACK_PACKAGE_NAME@" "URL Protocol" ""
-    WriteRegStr HKCR "@CPACK_PACKAGE_NAME@" "" "URL:Bitcoin-Cash-Node"
+    WriteRegStr HKCR "@CPACK_PACKAGE_NAME@" "" "URL:Bitcoin-Static"
     WriteRegStr HKCR "@CPACK_PACKAGE_NAME@\DefaultIcon" "" "$INSTDIR\${BITCOIN_GUI_NAME}"
     WriteRegStr HKCR "@CPACK_PACKAGE_NAME@\shell\open\command" "" '"$INSTDIR\${BITCOIN_GUI_NAME}" "%1"'
 SectionEnd

--- a/share/qt/Info.plist.in
+++ b/share/qt/Info.plist.in
@@ -38,7 +38,7 @@
   <true/>
 
   <key>CFBundleIdentifier</key>
-  <string>moe.ergon.BitcoinCashNode-Qt</string>
+  <string>moe.ergon.BitcoinStatic-Qt</string>
 
   <key>CFBundleURLTypes</key>
   <array>

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -153,14 +153,14 @@ void DebugMessageHandler(QtMsgType type, const QMessageLogContext &context,
     }
 }
 
-BitcoinCashNode::BitcoinCashNode(interfaces::Node &node) : QObject(), m_node(node) {}
+BitcoinStatic::BitcoinStatic(interfaces::Node &node) : QObject(), m_node(node) {}
 
-void BitcoinCashNode::handleRunawayException(const std::exception *e) {
+void BitcoinStatic::handleRunawayException(const std::exception *e) {
     PrintExceptionContinue(e, "Runaway exception");
     Q_EMIT runawayException(QString::fromStdString(m_node.getWarnings("gui")));
 }
 
-void BitcoinCashNode::initialize(Config *config, RPCServer *rpcServer,
+void BitcoinStatic::initialize(Config *config, RPCServer *rpcServer,
                             HTTPRPCRequestProcessor *httpRPCRequestProcessor) {
     try {
         qDebug() << __func__ << ": Running initialization in thread";
@@ -175,7 +175,7 @@ void BitcoinCashNode::initialize(Config *config, RPCServer *rpcServer,
     }
 }
 
-void BitcoinCashNode::shutdown() {
+void BitcoinStatic::shutdown() {
     try {
         qDebug() << __func__ << ": Running Shutdown in thread";
         m_node.appShutdown();
@@ -274,15 +274,15 @@ void BitcoinApplication::startThread() {
         return;
     }
     coreThread = new QThread(this);
-    BitcoinCashNode *executor = new BitcoinCashNode(m_node);
+    BitcoinStatic *executor = new BitcoinStatic(m_node);
     executor->moveToThread(coreThread);
 
     /*  communication to and from thread */
-    connect(executor, &BitcoinCashNode::initializeResult, this,
+    connect(executor, &BitcoinStatic::initializeResult, this,
             &BitcoinApplication::initializeResult);
-    connect(executor, &BitcoinCashNode::shutdownResult, this,
+    connect(executor, &BitcoinStatic::shutdownResult, this,
             &BitcoinApplication::shutdownResult);
-    connect(executor, &BitcoinCashNode::runawayException, this,
+    connect(executor, &BitcoinStatic::runawayException, this,
             &BitcoinApplication::handleRunawayException);
 
     // Note on how Qt works: it tries to directly invoke methods if the signal
@@ -299,10 +299,10 @@ void BitcoinApplication::startThread() {
     // crash because initialize() gets executed in another thread at some
     // unspecified time (after) requestedInitialize() is emitted!
     connect(this, &BitcoinApplication::requestedInitialize, executor,
-            &BitcoinCashNode::initialize);
+            &BitcoinStatic::initialize);
 
     connect(this, &BitcoinApplication::requestedShutdown, executor,
-            &BitcoinCashNode::shutdown);
+            &BitcoinStatic::shutdown);
     /*  make sure executor object is deleted in its own thread */
     connect(this, &BitcoinApplication::stopThread, executor,
             &QObject::deleteLater);

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -477,41 +477,6 @@ static void SetupUIArgs() {
 
 #ifndef BITCOIN_QT_TEST
 
-static void MigrateSettings() {
-    assert(!QApplication::applicationName().isEmpty());
-
-    static const QString abcAppName("BitcoinABC-Qt"),
-#ifdef Q_OS_DARWIN
-        // Macs and/or iOS et al use a domain-style name for Settings
-        // files. All other platforms use a simple orgname. This
-        // difference is documented in the QSettings class documentation.
-        abcOrg("bitcoinabc.org");
-#else
-        abcOrg("BitcoinABC");
-#endif
-    QSettings
-        // below picks up settings file location based on orgname,appname
-        abc(abcOrg, abcAppName),
-        // default c'tor below picks up settings file location based on
-        // QApplication::applicationName(), et al -- which was already set
-        // in main()
-        bchn;
-#ifdef Q_OS_DARWIN
-    // Disable bogus OSX keys from MacOS system-wide prefs that may cloud our
-    // judgement ;) (this behavior is also documented in QSettings docs)
-    abc.setFallbacksEnabled(false);
-    bchn.setFallbacksEnabled(false);
-#endif
-    // We only migrate settings if we have ABC settings but no ERGN
-    // settings (first run).
-    if (bchn.allKeys().isEmpty()) {
-        for (const QString &key : abc.allKeys()) {
-            // now, copy settings over
-            bchn.setValue(key, abc.value(key));
-        }
-    }
-}
-
 int GuiMain(int argc, char *argv[]) {
 #ifdef WIN32
     util::WinCmdLineArgs winArgs;
@@ -594,12 +559,6 @@ int GuiMain(int argc, char *argv[]) {
     QApplication::setOrganizationName(QAPP_ORG_NAME);
     QApplication::setOrganizationDomain(QAPP_ORG_DOMAIN);
     QApplication::setApplicationName(QAPP_APP_NAME_DEFAULT);
-    // Migrate GUI settings from Bitcoin ABC to our Bitcoin Static
-    // only if ABC's exists but ours doesn't.
-    // NOTE -- this function needs to be called *after* the above 3 lines
-    // that set the app orgname and app name! If you move the above 3 lines
-    // to elsewhere, take this call with you!
-    MigrateSettings();
 
     /// 4. Initialization of translations, so that intro dialog is in user's
     /// language. Now that QSettings are accessible, initialize translations.

--- a/src/qt/bitcoin.h
+++ b/src/qt/bitcoin.h
@@ -35,10 +35,10 @@ class Node;
  * Class encapsulating Bitcoin Static startup and shutdown.
  * Allows running startup and shutdown in a different thread from the UI thread.
  */
-class BitcoinCashNode : public QObject {
+class BitcoinStatic : public QObject {
     Q_OBJECT
 public:
-    explicit BitcoinCashNode(interfaces::Node &node);
+    explicit BitcoinStatic(interfaces::Node &node);
 
 public Q_SLOTS:
     void initialize(Config *config, RPCServer *rpcServer,

--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -47,11 +47,11 @@ static const int MAX_URI_LENGTH = 255;
 /* Number of frames in spinner animation */
 #define SPINNER_FRAMES 36
 
-#define QAPP_ORG_NAME "BitcoinCashNode"
-#define QAPP_ORG_DOMAIN "bitcoincashnode.org"
-#define QAPP_APP_NAME_DEFAULT "BitcoinCashNode-Qt"
-#define QAPP_APP_NAME_TESTNET "BitcoinCashNode-Qt-testnet"
-#define QAPP_APP_NAME_TESTNET4 "BitcoinCashNode-Qt-testnet4"
-#define QAPP_APP_NAME_SCALENET "BitcoinCashNode-Qt-scalenet"
+#define QAPP_ORG_NAME "BitcoinStatic"
+#define QAPP_ORG_DOMAIN "ergon.moe"
+#define QAPP_APP_NAME_DEFAULT "BitcoinStatic-Qt"
+#define QAPP_APP_NAME_TESTNET "BitcoinStatic-Qt-testnet"
+#define QAPP_APP_NAME_TESTNET4 "BitcoinStatic-Qt-testnet4"
+#define QAPP_APP_NAME_SCALENET "BitcoinStatic-Qt-scalenet"
 
 #endif // BITCOIN_QT_GUICONSTANTS_H

--- a/src/qt/macnotificationhandler.mm
+++ b/src/qt/macnotificationhandler.mm
@@ -12,7 +12,7 @@
 @implementation NSBundle (returnCorrectIdentifier)
 - (NSString *)__bundleIdentifier {
     if (self == [NSBundle mainBundle]) {
-        return @"org.bitcoincashnode.BitcoinCashNode-Qt";
+        return @"moe.ergon.BitcoinStatic-Qt";
     } else {
         return [self __bundleIdentifier];
     }

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -76,7 +76,7 @@ int main(int argc, char *argv[]) {
     // Don't remove this, it's needed to access
     // QApplication:: and QCoreApplication:: in the tests
     BitcoinApplication app(*node, argc, argv);
-    app.setApplicationName("BitcoinCashNode-Qt-test");
+    app.setApplicationName("BitcoinStatic-Qt-test");
 
 #ifdef ENABLE_BIP70
     // This is necessary to initialize openssl on the test framework


### PR DESCRIPTION
This is more rebranding and rename of BitcoinCashNode -> BitcoinStatic

It turns out it was overwriting bitcoin cash node's registry keys and
expecting to use bitcoin cash node's directory on windows. :/

On macos too there were issues with the app receiving "open URL" evens
properly (user clicking on ergon: links now works on macos).